### PR TITLE
fix typo : s/edting/editing/

### DIFF
--- a/Sample/TableViewAgent/Controller/SSViewController.m
+++ b/Sample/TableViewAgent/Controller/SSViewController.m
@@ -32,7 +32,7 @@
      ];
     agent.delegate = self;
     [agent setAdditionalCellId:kReuseAdd];
-    [agent setAdditionalCellMode:AdditionalCellModeHideEdting];
+    [agent setAdditionalCellMode:AdditionalCellModeHideEditing];
     [agent setEditableMode:EditableModeEnable];
 }
 

--- a/TableViewAgent/AdditionalCellState/AdditionalCellState.h
+++ b/TableViewAgent/AdditionalCellState/AdditionalCellState.h
@@ -16,7 +16,7 @@ typedef NS_ENUM (NSInteger, ChangeInState) {
 
 @interface AdditionalCellState : NSObject
 
-- (BOOL)isShowAddCell:(BOOL)edting;
-- (ChangeInState)changeInState:(BOOL)edting;
+- (BOOL)isShowAddCell:(BOOL) editing;
+- (ChangeInState)changeInState:(BOOL) editing;
 
 @end

--- a/TableViewAgent/AdditionalCellState/AdditionalCellState.m
+++ b/TableViewAgent/AdditionalCellState/AdditionalCellState.m
@@ -10,11 +10,11 @@
 
 @implementation AdditionalCellState
 
-- (BOOL)isShowAddCell:(BOOL)edting {
+- (BOOL)isShowAddCell:(BOOL) editing {
     return NO;
 }
 
-- (ChangeInState)changeInState:(BOOL)edting {
+- (ChangeInState)changeInState:(BOOL) editing {
     return ChangeInStateNone;
 }
 

--- a/TableViewAgent/AdditionalCellState/AdditionalCellStateAlways.m
+++ b/TableViewAgent/AdditionalCellState/AdditionalCellStateAlways.m
@@ -10,7 +10,7 @@
 
 @implementation AdditionalCellStateAlways
 
-- (BOOL)isShowAddCell:(BOOL)edting {
+- (BOOL)isShowAddCell:(BOOL) editing {
     return YES;
 }
 

--- a/TableViewAgent/AdditionalCellState/AdditionalCellStateHideEditing.m
+++ b/TableViewAgent/AdditionalCellState/AdditionalCellStateHideEditing.m
@@ -10,12 +10,12 @@
 
 @implementation AdditionalCellStateHideEditing
 
-- (BOOL)isShowAddCell:(BOOL)edting {
-    return edting == NO;
+- (BOOL)isShowAddCell:(BOOL) editing {
+    return editing == NO;
 }
 
-- (ChangeInState)changeInState:(BOOL)edting {
-    return (edting) ? ChangeInStateHide : ChangeInStateShow;
+- (ChangeInState)changeInState:(BOOL) editing {
+    return (editing) ? ChangeInStateHide : ChangeInStateShow;
 }
 
 @end

--- a/TableViewAgent/AdditionalCellState/AdditionalCellStateShowEditing.m
+++ b/TableViewAgent/AdditionalCellState/AdditionalCellStateShowEditing.m
@@ -10,12 +10,12 @@
 
 @implementation AdditionalCellStateShowEditing
 
-- (BOOL)isShowAddCell:(BOOL)edting {
-    return edting;
+- (BOOL)isShowAddCell:(BOOL) editing {
+    return editing;
 }
 
-- (ChangeInState)changeInState:(BOOL)edting {
-    return (edting == NO) ? ChangeInStateHide : ChangeInStateShow;
+- (ChangeInState)changeInState:(BOOL) editing {
+    return (editing == NO) ? ChangeInStateHide : ChangeInStateShow;
 }
 
 @end

--- a/TableViewAgent/TableViewAgent.h
+++ b/TableViewAgent/TableViewAgent.h
@@ -37,8 +37,10 @@ typedef id override_id;
 typedef NS_ENUM (NSInteger, AdditionalCellMode) {
     AdditionalCellModeNone,
     AdditionalCellModeAlways,
-    AdditionalCellModeHideEdting,
-    AdditionalCellModeShowEdting,
+    AdditionalCellModeHideEditing,
+    AdditionalCellModeShowEditing,
+    AdditionalCellModeHideEdting __attribute__((deprecated)),
+    AdditionalCellModeShowEdting __attribute__((deprecated)),
 };
 typedef NS_ENUM (NSInteger, EditableMode) {
     EditableModeNone,

--- a/TableViewAgent/TableViewAgent.m
+++ b/TableViewAgent/TableViewAgent.m
@@ -67,6 +67,12 @@
         case AdditionalCellModeAlways : {
             addState = [AdditionalCellStateAlways new];
         } break;
+        case AdditionalCellModeHideEditing: {
+            addState = [AdditionalCellStateHideEditing new];
+        } break;
+        case AdditionalCellModeShowEditing: {
+            addState = [AdditionalCellStateShowEditing new];
+        } break;
         case AdditionalCellModeHideEdting: {
             addState = [AdditionalCellStateHideEditing new];
         } break;


### PR DESCRIPTION
@akuraru 
typoを直すのにあたってNS_ENUMに以下を追加する代わりに

``` objc
AdditionalCellModeHideEditing,
AdditionalCellModeShowEditing,
```

元々のものついては`__attribute__((deprecated))`
を付けて互換性のために残すようにしました。

``` objc
AdditionalCellModeHideEdting __attribute__((deprecated)),
AdditionalCellModeShowEdting __attribute__((deprecated)),
```
